### PR TITLE
Added methods for getting a decoded token

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,9 +28,12 @@
     "@blackbaud/auth-client": "^2.7.0",
     "@skyux/config": "^3.0.0"
   },
-  "dependencies": {},
+  "dependencies": {
+    "jwt-decode": "2.2.0"
+  },
   "devDependencies": {
     "@blackbaud/skyux": "2.30.0",
-    "@blackbaud/skyux-builder": "1.29.0"
+    "@blackbaud/skyux-builder": "1.29.0",
+    "@types/jwt-decode": "2.2.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,8 +32,8 @@
     "jwt-decode": "2.2.0"
   },
   "devDependencies": {
-    "@blackbaud/skyux": "2.30.0",
-    "@blackbaud/skyux-builder": "1.29.0",
+    "@blackbaud/skyux": "2.49.1",
+    "@blackbaud/skyux-builder": "1.34.1",
     "@types/jwt-decode": "2.2.1"
   }
 }

--- a/src/app/public/modules/auth-http-client/auth-interceptor.ts
+++ b/src/app/public/modules/auth-http-client/auth-interceptor.ts
@@ -23,8 +23,9 @@ import {
 } from '@skyux/config';
 
 import {
+  SkyAuthTokenContextArgs,
   SkyAuthTokenProvider
-} from '../auth-http/auth-token-provider';
+} from '../auth-http';
 
 import {
   SKY_AUTH_PARAM_AUTH,
@@ -78,24 +79,14 @@ export class SkyAuthInterceptor implements HttpInterceptor {
     }
 
     if (auth) {
-      const leId = this.getLeId();
-      const envId = this.getEnvId();
-      const tokenArgs: any = {};
+      const tokenContextArgs: SkyAuthTokenContextArgs = {};
 
       if (permissionScope) {
-        tokenArgs.permissionScope = permissionScope;
-      }
-
-      if (envId) {
-        tokenArgs.envId = envId;
-      }
-
-      if (leId) {
-        tokenArgs.leId = leId;
+        tokenContextArgs.permissionScope = permissionScope;
       }
 
       return Observable
-        .fromPromise(this.tokenProvider.getToken(tokenArgs))
+        .fromPromise(this.tokenProvider.getContextToken(tokenContextArgs))
         .switchMap((token) => {
           let authRequest = request.clone({
             setHeaders: {
@@ -109,14 +100,6 @@ export class SkyAuthInterceptor implements HttpInterceptor {
     }
 
     return next.handle(request);
-  }
-
-  private getEnvId(): string {
-    return this.config.runtime.params.get('envid');
-  }
-
-  private getLeId(): string {
-    return this.config.runtime.params.get('leid');
   }
 
 }

--- a/src/app/public/modules/auth-http/auth-token-context-args.ts
+++ b/src/app/public/modules/auth-http/auth-token-context-args.ts
@@ -1,0 +1,5 @@
+export interface SkyAuthTokenContextArgs {
+
+  permissionScope?: string;
+
+}

--- a/src/app/public/modules/auth-http/auth-token-provider.spec.ts
+++ b/src/app/public/modules/auth-http/auth-token-provider.spec.ts
@@ -1,22 +1,186 @@
-import { BBAuth } from '@blackbaud/auth-client';
+//#region imports
 
-import { SkyAuthTokenProvider } from './auth-token-provider';
+import {
+  BBAuth
+} from '@blackbaud/auth-client';
+
+import {
+  SkyAuthToken
+} from './auth-token';
+
+import {
+  SkyAuthTokenProvider
+} from './auth-token-provider';
+
+//#endregion
 
 describe('Auth token provider', () => {
 
-  it('should call BBAuth.getToken and add return its promise', (done) => {
-    const expectedToken = 'my-fake-token';
+  let testToken: string;
 
-    spyOn(BBAuth, 'getToken')
-      .and
-      .returnValue(Promise.resolve(expectedToken));
+  let testDecodedToken: SkyAuthToken;
 
-    const provider = new SkyAuthTokenProvider();
+  beforeEach(() => {
+    testToken = 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9' +
+      '.eyJzdWIiOiIxMjM0NTY3ODkwIiwiZ2l2ZW5fbmFtZSI6IkpvaG4iLCJmYW1pbHl' + 'fbmFtZSI6IkRvZSIsImlhdCI6MTUxNjIzOTAyMn0' +
+      '.M44YpCNOgfbfofdWeIGLHoMwmeKAEibhDIcDCgRM5Nc';
 
-    provider.getToken().then((token: string) => {
-      expect(token).toBe(expectedToken);
-      done();
+    testDecodedToken = {
+      sub: '1234567890',
+      given_name: 'John',
+      family_name: 'Doe',
+      iat: 1516239022
+    };
+  });
+
+  describe('getToken() method', () => {
+
+    it('should call BBAuth.getToken and add return its promise', (done) => {
+      spyOn(BBAuth, 'getToken')
+        .and
+        .returnValue(Promise.resolve(testToken));
+
+      const provider = new SkyAuthTokenProvider();
+
+      provider.getToken().then((token) => {
+        expect(token).toBe(testToken);
+        done();
+      });
     });
+
+  });
+
+  describe('getDecodedToken() method', () => {
+
+    it('should return a decoded token', (done) => {
+      spyOn(BBAuth, 'getToken')
+        .and
+        .returnValue(Promise.resolve(testToken));
+
+      const provider = new SkyAuthTokenProvider();
+
+      provider.getDecodedToken().then((token) => {
+        expect(token).toEqual(testDecodedToken);
+
+        done();
+      });
+    });
+
+  });
+
+  describe('getContextToken() method', () => {
+
+    it('should call BBAuth.getToken() with the SPA\'s context parameters', () => {
+      const getTokenSpy = spyOn(BBAuth, 'getToken');
+
+      let provider = new SkyAuthTokenProvider({
+        runtime: {
+          params: {
+            get: (name: string) => {
+              switch (name) {
+                case 'envid':
+                  return 'test-envid';
+                default:
+                  return undefined;
+              }
+            }
+          }
+        }
+      } as any);
+
+      provider.getContextToken();
+
+      expect(getTokenSpy).toHaveBeenCalledWith({
+        envId: 'test-envid'
+      });
+
+      provider = new SkyAuthTokenProvider({
+        runtime: {
+          params: {
+            get: (name: string) => {
+              switch (name) {
+                case 'leid':
+                  return 'test-leid';
+                default:
+                  return undefined;
+              }
+            }
+          }
+        }
+      } as any);
+
+      provider.getContextToken();
+
+      expect(getTokenSpy).toHaveBeenCalledWith({
+        leId: 'test-leid'
+      });
+    });
+
+    it('should handle missing config', () => {
+      const getTokenSpy = spyOn(BBAuth, 'getToken');
+
+      const provider = new SkyAuthTokenProvider();
+
+      provider.getContextToken();
+
+      expect(getTokenSpy).toHaveBeenCalledWith({});
+    });
+
+    it('should add permission scope to the request if specified', () => {
+      const getTokenSpy = spyOn(BBAuth, 'getToken');
+
+      const provider = new SkyAuthTokenProvider();
+
+      provider.getContextToken({
+        permissionScope: 'abc'
+      });
+
+      expect(getTokenSpy).toHaveBeenCalledWith({
+        permissionScope: 'abc'
+      });
+    });
+
+  });
+
+  describe('getDecodedContextToken() method', () => {
+
+    it(
+      'should call BBAuth.getToken() with the SPA\'s context parameters and decode the token',
+      (done) => {
+        const getTokenSpy = spyOn(BBAuth, 'getToken')
+          .and
+          .returnValue(Promise.resolve(testToken));
+
+        const provider = new SkyAuthTokenProvider({
+          runtime: {
+            params: {
+              get: (name: string) => {
+                switch (name) {
+                  case 'leid':
+                    return 'test-leid';
+                  default:
+                    return undefined;
+                }
+              }
+            }
+          }
+        } as any);
+
+        provider.getDecodedContextToken({
+          permissionScope: 'xyz'
+        }).then((token) => {
+          expect(getTokenSpy).toHaveBeenCalledWith({
+            leId: 'test-leid',
+            permissionScope: 'xyz'
+          });
+
+          expect(token).toEqual(testDecodedToken);
+
+          done();
+        });
+      }
+    );
+
   });
 
 });

--- a/src/app/public/modules/auth-http/auth-token-provider.ts
+++ b/src/app/public/modules/auth-http/auth-token-provider.ts
@@ -1,15 +1,118 @@
+//#region imports
+
 import {
-  Injectable
+  Injectable,
+  Optional
 } from '@angular/core';
+
+import * as jwtDecode from 'jwt-decode';
+
+import {
+  SkyAppConfig
+} from '@skyux/config';
 
 import {
   BBAuth,
   BBAuthGetTokenArgs
 } from '@blackbaud/auth-client';
 
+import {
+  SkyAuthToken
+} from './auth-token';
+
+import {
+  SkyAuthTokenContextArgs
+} from './auth-token-context-args';
+
+//#endregion
+
+/**
+ * Provides methods for getting JWT tokens from the Blackbaud authentication service.
+ */
 @Injectable()
 export class SkyAuthTokenProvider {
+
+  constructor (
+    @Optional() private config?: SkyAppConfig
+  ) { }
+
+  /**
+   * Gets a token string from the Blackbaud authentication service.
+   * @param args Options for retrieving a token.
+   */
   public getToken(args?: BBAuthGetTokenArgs): Promise<string> {
     return BBAuth.getToken(args);
   }
+
+  /**
+   * Gets a token object from the Blackbaud authentication service.
+   * @param args Options for retrieving a token.
+   */
+  public getDecodedToken(args?: BBAuthGetTokenArgs): Promise<SkyAuthToken> {
+    return new Promise<SkyAuthToken>((resolve, reject) => {
+      this.getToken(args)
+        .then(
+          (token) => {
+            resolve(this.decodeToken(token));
+          },
+          reject
+        );
+    });
+  }
+
+  /**
+   * Gets a token string from the Blackbaud authentication service using the SPA's environment/
+   * legal entity context.
+   * @param args Provides additional context for retrieving the token.
+   */
+  public getContextToken(args?: SkyAuthTokenContextArgs): Promise<String> {
+    const tokenArgs = this.getContextArgs(args);
+
+    return this.getToken(tokenArgs);
+  }
+
+  /**
+   * Gets a token object from the Blackbaud authentication service using the SPA's environment/
+   * legal entity context.
+   * @param args Provides additional context for retrieving the token.
+   */
+  public getDecodedContextToken(args?: SkyAuthTokenContextArgs): Promise<SkyAuthToken> {
+    const tokenArgs = this.getContextArgs(args);
+
+    return this.getDecodedToken(tokenArgs);
+  }
+
+  /**
+   * Decodes a token string.
+   * @param token The token string to decode.
+   */
+  public decodeToken(token: string): SkyAuthToken {
+    return jwtDecode<SkyAuthToken>(token);
+  }
+
+  private getContextArgs(args: SkyAuthTokenContextArgs): BBAuthGetTokenArgs {
+    const tokenArgs: BBAuthGetTokenArgs = {};
+
+    if (this.config) {
+      const runtimeParams = this.config.runtime.params;
+
+      const envId = runtimeParams.get('envid');
+      const leId = runtimeParams.get('leid');
+
+      if (envId) {
+        tokenArgs.envId = envId;
+      }
+
+      if (leId) {
+        tokenArgs.leId = leId;
+      }
+    }
+
+    if (args && args.permissionScope) {
+      tokenArgs.permissionScope = args.permissionScope;
+    }
+
+    return tokenArgs;
+  }
+
 }

--- a/src/app/public/modules/auth-http/auth-token.ts
+++ b/src/app/public/modules/auth-http/auth-token.ts
@@ -1,0 +1,78 @@
+export interface SkyAuthToken {
+
+  /**
+   * The subject of the token and contains the user's Blackbaud Authentication Id (GUID).
+   */
+  sub?: string;
+
+  /**
+   * The user's email address.
+   */
+  email?: string;
+
+  /**
+   * The first name of the user.
+   */
+  given_name?: string;
+
+  /**
+   * The last name of the user.
+   */
+  family_name?: string;
+
+  /**
+   * Blackbaud session ID.
+   */
+  '1bb.session_id'?: string;
+
+  /**
+   * Single permission or array of permissions based on the provided permission scope.
+   */
+  '1bb.perms'?: number | number[];
+
+  /**
+   * The environment ID provided when the token was created.
+   */
+  '1bb.environment_id'?: string;
+
+  /**
+   * The legal entity ID provided when the token was created.
+   */
+  '1bb.legal_entity_id'?: string;
+
+  /**
+   * The permission scope provided when the token was created.
+   */
+  '1bb.permission_scope'?: string;
+
+  /**
+   * The zone that the environment is in.
+   */
+  '1bb.zone'?: string;
+
+  /**
+   * Single entitlement or array of entitlements based on the provided permission scope.
+   */
+  '1bb.entitlements'?: string | string[];
+
+  /**
+   * The time that the token expires and consumers should not accept the token.
+   */
+  exp?: number;
+
+  /**
+   * The time that the JWT was created.
+   */
+  iat?: number;
+
+  /**
+   * The issuer of the token (the Authentication Service).
+   */
+  iss?: string;
+
+  /**
+   * The intended audience of the JWT.
+   */
+  aud?: string;
+
+}

--- a/src/app/public/modules/auth-http/index.ts
+++ b/src/app/public/modules/auth-http/index.ts
@@ -1,3 +1,5 @@
 export * from './auth-http.module';
 export * from './auth-http';
+export * from './auth-token';
+export * from './auth-token-context-args';
 export * from './auth-token-provider';


### PR DESCRIPTION
This will allow consumers to get the zone from the JWT without having to decode it themselves.  Also added methods to get a token based on the SPA's current `envid`/`leid` parameters so they don't have to be provided explicitly by the consumer.