### PR TITLE
Added convenience method to use for `responseType` of `json`

### DIFF
--- a/src/app/public/modules/auth-http-client/auth-options.spec.ts
+++ b/src/app/public/modules/auth-http-client/auth-options.spec.ts
@@ -5,6 +5,7 @@ import {
 } from '@angular/common/http';
 
 import {
+  skyAuthHttpJsonOptions,
   skyAuthHttpOptions
 } from './auth-options';
 
@@ -35,6 +36,12 @@ describe('Auth options', () => {
     });
 
     expect(options.params.get('abc')).toBe('123');
+  });
+
+  it('should provide a method that enforces a responseType of json', () => {
+    const options = skyAuthHttpJsonOptions();
+
+    expect(options.responseType).toBe('json');
   });
 
 });

--- a/src/app/public/modules/auth-http-client/auth-options.ts
+++ b/src/app/public/modules/auth-http-client/auth-options.ts
@@ -40,3 +40,36 @@ export function skyAuthHttpOptions(options?: {
 
   return options;
 }
+
+/**
+ * Provides the standard options expected by Angular's HttpClient methods along with
+ * additional options for making requests to services protected by Blackbaud ID and
+ * ensures that the subsequent call to `HttpClient` returns the generic type passed
+ * to it by enforcing a `responseType` of `'json'`.
+ * @param options
+ */
+export function skyAuthHttpJsonOptions(options?: {
+  body?: any,
+  headers?: HttpHeaders,
+  observe?: HttpObserve,
+  params?: HttpParams,
+  reportProgress?: boolean,
+  permissionScope?: string,
+  responseType?: 'json',
+  withCredentials?: boolean
+}): {
+  body?: any,
+  headers?: HttpHeaders,
+  observe?: HttpObserve,
+  params?: HttpParams,
+  reportProgress?: boolean,
+  permissionScope?: string,
+  responseType?: 'json',
+  withCredentials?: boolean
+} {
+  options = options || {};
+
+  options.responseType = 'json';
+
+  return skyAuthHttpOptions(options);
+}


### PR DESCRIPTION
This keeps consumers from having to cast the result of `skyAuthHttpOptions` to get generic typing working with web requests.

Closes #15 