### PR TITLE
[rc] Drop `rxjs-compat`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10539,12 +10539,6 @@
         "tslib": "^1.9.0"
       }
     },
-    "rxjs-compat": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/rxjs-compat/-/rxjs-compat-6.5.3.tgz",
-      "integrity": "sha512-BIJX2yovz3TBpjJoAZyls2QYuU6ZiCaZ+U96SmxQpuSP/qDUfiXPKOVLbThBB2WZijNHkdTTJXKRwvv5Y48H7g==",
-      "dev": true
-    },
     "safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,6 @@
     "codelyzer": "4.5.0",
     "core-js": "2.6.9",
     "rxjs": "6.5.3",
-    "rxjs-compat": "6.5.3",
     "ts-node": "8.4.1",
     "tslint": "5.20.0",
     "typescript": "3.2.4",

--- a/src/app/public/modules/auth-http-client/auth-interceptor.spec.ts
+++ b/src/app/public/modules/auth-http-client/auth-interceptor.spec.ts
@@ -11,15 +11,13 @@ import {
 } from '@angular/core/testing';
 
 import {
-  Observable
-} from 'rxjs/Observable';
-
-import 'rxjs/add/observable/of';
-
-import {
   SkyAppConfig,
   SkyAppRuntimeConfigParams
 } from '@skyux/config';
+
+import {
+  of as observableOf
+} from 'rxjs';
 
 import {
   SkyAuthTokenContextArgs,
@@ -101,7 +99,7 @@ describe('Auth interceptor', () => {
     next.handle.and.callFake((authRequest: HttpRequest<any>) => {
       cb(authRequest);
       done();
-      return Observable.of('');
+      return observableOf('');
     });
   }
 


### PR DESCRIPTION
**Breaking changes:**
- This library will not work in a SKY UX 2 SPA without `rxjs-compat` installed.